### PR TITLE
Exclude current object's record from search when updating it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+
+ before_script:
+  - composer install --no-interaction
+
+ script:
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
+
 php:
-  - 5.6
   - 7.0
   - 7.1
 
- before_script:
-  - composer install --no-interaction
+sudo: false
 
- script:
-  - vendor/bin/phpunit
+install: travis_retry composer install --no-interaction --prefer-source
+
+script: vendor/bin/phpunit

--- a/src/EasySlug/EasySlug/EasySlug.php
+++ b/src/EasySlug/EasySlug/EasySlug.php
@@ -26,28 +26,28 @@ class EasySlug
      *
      * @return string
      */
-    public function generateUniqueSlug( $string , $table , $column = "slug" , $separator = "-" )
+    public function generateUniqueSlug( $string , $table , $column = "slug" , $separator = "-", $id)
     {
         $temporary_slug = $this->generateSlug( $string , "-" );
 
         $count_of_matching_slugs = $this->_easy_slug_repo
             ->getCountOfMatchingSlugs( $table , $column ,
-                                       $temporary_slug );
+                $temporary_slug, $id);
 
         if ( $count_of_matching_slugs > 0 )
         {
-            $temporary_slug = $this->generateSlug( $string . " " . ( $count_of_matching_slugs + 1 ) , $separator );
+            $temporary_slug = $this->generateSlug( $string . " " . ( $count_of_matching_slugs + 1 ) , $separator, $id);
 
             $flag = false;
 
             $i = 2;
             while($flag == false)
             {
-                $exact_slugs = $this->_easy_slug_repo->getCountOfExactSlugs($table, $column, $temporary_slug);
+                $exact_slugs = $this->_easy_slug_repo->getCountOfExactSlugs($table, $column, $temporary_slug, $id);
 
                 if($exact_slugs > 0)
                 {
-                    $temporary_slug = $this->generateSlug( $string . " " . ( $count_of_matching_slugs + $i ) , $separator );
+                    $temporary_slug = $this->generateSlug( $string . " " . ( $count_of_matching_slugs + $i ) , $separator, $id);
                     $i++;
                 }
                 else
@@ -59,7 +59,7 @@ class EasySlug
         else {
             $keywords = explode('-', $temporary_slug);
             $total_keywords = count($keywords);
-            
+
             if ( is_numeric($keywords[$total_keywords-1]) )
             {
                 return $temporary_slug;

--- a/src/EasySlug/EasySlug/EasySlugRepository.php
+++ b/src/EasySlug/EasySlug/EasySlugRepository.php
@@ -13,19 +13,19 @@ class EasySlugRepository
      *
      * @return mixed
      */
-    public function getCountOfMatchingSlugs( $table , $column , $slug )
+    public function getCountOfMatchingSlugs( $table , $column , $slug, $id)
     {
         $keywords = explode('-', $slug);
         $total_keywords = count($keywords);
         if ( is_numeric($keywords[$total_keywords-1]) )
         {
-            return DB::table( $table )->where( $column , 'LIKE' , $slug . '-' . '%' )->count();
+            return DB::table( $table )->where( $column , 'LIKE' , $slug . '-' . '%' )->where('id','!=',$id)->count();
         }
-        return DB::table( $table )->where( $column , 'LIKE' , $slug . '%' )->count();
+        return DB::table( $table )->where( $column , 'LIKE' , $slug . '%' )->where('id','!=',$id)->count();
     }
 
-    public function getCountOfExactSlugs( $table , $column , $slug )
+    public function getCountOfExactSlugs( $table , $column , $slug, $id)
     {
-        return DB::table( $table )->where( $column , $slug )->count();
+        return DB::table( $table )->where( $column , $slug )->where('id','!=',$id)->count();
     }
 }

--- a/tests/EasySlugTest.php
+++ b/tests/EasySlugTest.php
@@ -33,7 +33,7 @@ class EasySlugTest extends PHPUnit_Framework_TestCase
         $this->repo->shouldReceive('getCountOfMatchingSlugs')->andReturn(1);
         $this->repo->shouldReceive('getCountOfExactSlugs')->andReturn(0);
 
-        $slug = $this->easySlug->generateUniqueSlug('viraj khatavkar', 'demo');
+        $slug = $this->easySlug->generateUniqueSlug('viraj khatavkar', 'demo', 1);
 
         $this->assertEquals('viraj-khatavkar-2', $slug);
     }
@@ -43,7 +43,7 @@ class EasySlugTest extends PHPUnit_Framework_TestCase
         $this->repo->shouldReceive('getCountOfMatchingSlugs')->andReturn(1);
         $this->repo->shouldReceive('getCountOfExactSlugs')->andReturn(0);
 
-        $slug = $this->easySlug->generateUniqueSlug('mangesh', 'demo');
+        $slug = $this->easySlug->generateUniqueSlug('mangesh', 'demo', 1);
 
         $this->assertEquals('mangesh-2', $slug);
     }

--- a/tests/EasySlugTest.php
+++ b/tests/EasySlugTest.php
@@ -33,7 +33,7 @@ class EasySlugTest extends PHPUnit_Framework_TestCase
         $this->repo->shouldReceive('getCountOfMatchingSlugs')->andReturn(1);
         $this->repo->shouldReceive('getCountOfExactSlugs')->andReturn(0);
 
-        $slug = $this->easySlug->generateUniqueSlug('viraj khatavkar', 'demo', '-', 1);
+        $slug = $this->easySlug->generateUniqueSlug('viraj khatavkar', 'demo', 'slug', '-', 1);
 
         $this->assertEquals('viraj-khatavkar-2', $slug);
     }
@@ -43,7 +43,7 @@ class EasySlugTest extends PHPUnit_Framework_TestCase
         $this->repo->shouldReceive('getCountOfMatchingSlugs')->andReturn(1);
         $this->repo->shouldReceive('getCountOfExactSlugs')->andReturn(0);
 
-        $slug = $this->easySlug->generateUniqueSlug('mangesh', 'demo', '-', 1);
+        $slug = $this->easySlug->generateUniqueSlug('mangesh', 'demo', 'slug', '-', 1);
 
         $this->assertEquals('mangesh-2', $slug);
     }

--- a/tests/EasySlugTest.php
+++ b/tests/EasySlugTest.php
@@ -33,7 +33,7 @@ class EasySlugTest extends PHPUnit_Framework_TestCase
         $this->repo->shouldReceive('getCountOfMatchingSlugs')->andReturn(1);
         $this->repo->shouldReceive('getCountOfExactSlugs')->andReturn(0);
 
-        $slug = $this->easySlug->generateUniqueSlug('viraj khatavkar', 'demo', 1);
+        $slug = $this->easySlug->generateUniqueSlug('viraj khatavkar', 'demo', '-', 1);
 
         $this->assertEquals('viraj-khatavkar-2', $slug);
     }
@@ -43,7 +43,7 @@ class EasySlugTest extends PHPUnit_Framework_TestCase
         $this->repo->shouldReceive('getCountOfMatchingSlugs')->andReturn(1);
         $this->repo->shouldReceive('getCountOfExactSlugs')->andReturn(0);
 
-        $slug = $this->easySlug->generateUniqueSlug('mangesh', 'demo', 1);
+        $slug = $this->easySlug->generateUniqueSlug('mangesh', 'demo', '-', 1);
 
         $this->assertEquals('mangesh-2', $slug);
     }


### PR DESCRIPTION
I saw that when updating different objects the slug was getting a '-2' when it was the only slug with that content, so i thought about this changes.